### PR TITLE
Dockerfile plus docker-compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+.dockerignore
+.gitignore
+README.md
+
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 coverage.json
 coverage/
 node_modules/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:9.2.0
+
+WORKDIR /app
+
+RUN npm install -g truffle
+
+COPY package.json .
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD npm start

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+docker_migrate:
+	docker-compose exec truffle truffle migrate --network=development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.4'
+services:
+  truffle:
+    build: .
+    command: truffle develop
+    volumes:
+      - ./build:/app/build
+      - ./contracts:/app/contracts
+      - ./migrations:/app/migrations
+    tty: true
+    stdin_open: true
+    ports:
+      - "9545:9545"
+
+  eth-bridge:
+    image: marketproject/ethereum-bridge:0.5.6
+    command: -H truffle:9545 -a 9 --dev
+    restart: unless-stopped
+    depends_on:
+      - truffle
+    links:
+      - truffle
+
+  app:
+    build: .
+    volumes:
+      - ./build:/app/build
+      - ./config:/app/config
+      - ./public:/app/public
+      - ./src:/app/src
+    ports:
+      - "3000:3000"
+    depends_on:
+      - truffle

--- a/truffle.js
+++ b/truffle.js
@@ -1,4 +1,11 @@
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 9545,
+      network_id: "*" // Match any network id
+    }
+  }
 };


### PR DESCRIPTION
Taking a stab at setting up docker-compose for the Dapp. Followed some of the `docker-compose.yml` setup found at https://github.com/MarketProject/MarketProtocol

# Positives:
* Now allows for you to get started with your dev environment by typing `docker-compose up`
* Keeps everything self-contained. You don't even need to install truffle on your machine now.
* No node_modules on your host machine
* If you do have truffle installed on your machine, you can access the network setup by the truffle container with `truffle console --network development`
* react app still auto rebuilds whenever you change files locally

# Downsides
* Migration still has to be done manually. I added a Makefile so that it's as easy as `make docker_migrate`. Def open to alternatives here.
* Adding new deps requires the Docker image to be re-built.

I'm using this while I work on the "deploy contract" form stuff to test it out a bit more.
Thoughts on this?