### PR TITLE
Price cap and price floor validate together

### DIFF
--- a/src/components/DeployContractField.js
+++ b/src/components/DeployContractField.js
@@ -76,7 +76,19 @@ const fieldSettingsByName = {
     },
     extra: 'Placeholder explanation',
 
-    component: () => (<InputNumber min={0} style={{ width: '100%' }} />)
+    component: ({ form }) => {
+      return (
+        <InputNumber
+          min={0}
+          style={{ width: '100%' }}
+          onChange={() => {
+            setTimeout(() => {
+              form.validateFields(['priceCap'], { force: true });
+            }, 100);
+          }}
+        />
+      );
+    }
   },
 
   priceCap: {
@@ -101,6 +113,11 @@ const fieldSettingsByName = {
         <InputNumber
           min={0}
           style={{ width: '100%' }}
+          onChange={() => {
+            setTimeout(() => {
+              form.validateFields(['priceFloor'], { force: true });
+            }, 100);
+          }}
         />
       );
     }


### PR DESCRIPTION
Fixes https://github.com/MarketProject/Dapp/issues/14

Change causes both `priceCap` and `priceFloor` fields to be validated at the same time when one of them changes.

![](http://g.recordit.co/sN9b8XjBXV.gif)
