### PR TITLE
Adding contract address to deploy message

### DIFF
--- a/src/components/DeployContractForm.js
+++ b/src/components/DeployContractForm.js
@@ -4,6 +4,7 @@ import { Row, Col, Form, Button } from 'antd';
 import showMessage from './message';
 import Loader from './Loader';
 import Field from './DeployContractField';
+import DeployContractSuccess from './DeployContractSuccess';
 
 const formButtonLayout = {
   xs: {
@@ -50,7 +51,7 @@ class DeployContractForm extends Component {
         showMessage('error', `There was an error deploying the contract: ${nextProps.error}`, 8);
       } else if (nextProps.contract) {
         // Contract was deployed
-        showMessage('success', 'Contract successfully deployed', 5);
+        showMessage('success', DeployContractSuccess({ contract: nextProps.contract }), 5);
       }
     }
   }

--- a/src/components/DeployContractSuccess.js
+++ b/src/components/DeployContractSuccess.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function DeployContractSuccess({ contract }) {
+  return (
+    <span>
+      Contract successfully deployed at: <a href={`https://etherscan.io/address/${contract.address}`} target="_blank">{contract.address}</a>
+    </span>
+  );
+}
+
+export default DeployContractSuccess


### PR DESCRIPTION
Closes https://github.com/MarketProject/Dapp/issues/15

<img width="707" alt="dapp___market_protocol" src="https://user-images.githubusercontent.com/766596/35659187-8b6bae90-06ca-11e8-9898-f8c2cc7a3f17.png">

Clicking on the url takes you to the etherscan page for the contract address (obviously, will be most helpful when this is deployed to mainnet).

If we think the link isn't a good idea, I can get rid of it. We could also do other things like make so if you click the link, instead of taking you to etherscan, it'd copy the address to your clipboard or something. 