### PR TITLE
Use the deployed instance as contract payload

### DIFF
--- a/src/actions/deploy.js
+++ b/src/actions/deploy.js
@@ -92,7 +92,7 @@ export function deployContract(contractSpecs) {
               { from: web3.eth.accounts[0] }
             );
 
-            dispatch({ type: `${type}_FULFILLED`, payload: marketContract });
+            dispatch({ type: `${type}_FULFILLED`, payload: marketContractInstanceDeployed });
           })
           .catch(err => {
             dispatch({ type: `${type}_REJECTED`, payload: err });


### PR DESCRIPTION
When dispatching the "DEPLOY_CONTRACT_FULFILLED" event, the payload should be the market contract instance that we just deployed to the blockchain. Seem reasonable?