### PR TITLE
Added styling for sample query list

### DIFF
--- a/src/components/DeployContract/DeployContractField.js
+++ b/src/components/DeployContract/DeployContractField.js
@@ -39,7 +39,7 @@ const oracleQueryValidator = (form, rule, value, callback) => {
 
   if (dataSourceObj) {
     callback(dataSourceObj.isQueryValid(oracleQuery) ? undefined
-    : `Invalid Query for '${oracleDataSource}' Data Source. A valid example is: ${dataSourceObj.sampleQueries[0]}`);
+    : `Invalid Query for '${oracleDataSource}' Data Source. A valid example is: ${dataSourceObj.sampleQueries[0].query}`);
   } else {
     callback(undefined);
   }

--- a/src/components/Step.css
+++ b/src/components/Step.css
@@ -26,3 +26,13 @@
 .step-leave {
   opacity: 0;
 }
+
+.sample-query {
+  background-color: #f0f2f5;
+  border-radius: 2px;
+  color: #314659;
+  font-family: "Lucida Console", Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-size: 13px;
+  padding: 12px 20px;
+  margin: 16px 0;
+}

--- a/src/components/TestQuery/OracleDataSources.js
+++ b/src/components/TestQuery/OracleDataSources.js
@@ -55,9 +55,15 @@ const OracleDataSources = [
         return query.length !== 0;
       },
       sampleQueries: [
-        'AAPL Price',
-        'Temperature in Boulder, CO',
-        'S&P 500 Index Price'
+        {
+          query: 'AAPL PRICE',
+        },
+        {
+          query: 'Temperature in Boulder, CO',
+        },
+        {
+          query: 'S&P 500 Index Price',
+        }
       ]
     },
     {
@@ -78,7 +84,9 @@ const OracleDataSources = [
         return isIPFS.multihash(query);
       },
       sampleQueries: [
-        'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o'
+        {
+          query: 'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o',
+        }
       ]
     },
     {
@@ -109,7 +117,9 @@ const OracleDataSources = [
         return query.length !== 0;
       },
       sampleQueries: [
-        'QmRxtL9K2de7v7QBYCCrwcjZHjYmuKggZ8xaqZ6UUWvd1s'
+        {
+          query: 'QmRxtL9K2de7v7QBYCCrwcjZHjYmuKggZ8xaqZ6UUWvd1s',
+        }
       ]
     }
   ];

--- a/src/components/TestQuery/OracleDataSources.js
+++ b/src/components/TestQuery/OracleDataSources.js
@@ -28,9 +28,18 @@ const OracleDataSources = [
             .test(query);
       },
       sampleQueries: [
-        'json(https://api.gdax.com/products/BTC-USD/ticker).price - Price of BTC-USD on GDAX',
-        'json(https://api.kraken.com/0/public/Ticker?pair=ETHUSD).result.XETHZUSD.p.1 - Volume Weight Average Price (24 hrs) of ETH-USD on Kraken',
-        'json(https://api.bitfinex.com/v1/pubticker/omgeth).mid - Mid Price of OMG-ETH',
+        {
+          query: 'json(https://api.gdax.com/products/BTC-USD/ticker).price',
+          title: 'Price of BTC-USD on GDAX',
+        },
+        {
+          query: 'json(https://api.kraken.com/0/public/Ticker?pair=ETHUSD).result.XETHZUSD.p.1',
+          title: 'Volume Weight Average Price (24 hrs) of ETH-USD on Kraken',
+        },
+        {
+          query: 'json(https://api.bitfinex.com/v1/pubticker/omgeth).mid',
+          title: 'Mid Price of OMG-ETH',
+        }
       ]
     },
     {

--- a/src/components/TestQuery/Steps.js
+++ b/src/components/TestQuery/Steps.js
@@ -182,7 +182,7 @@ class SetQueryStep extends Component {
               {getDataSourceObj(dataSource).sampleQueries.map(sample => {
                 return (
                   <div className="sample-query-item">
-                    <div className="sample-query-title">{sample.title}:</div>
+                    { sample.title && <div className="sample-query-title">{sample.title}:</div> }
                     <div className="sample-query">{sample.query}</div>
                   </div>
                 );

--- a/src/components/TestQuery/Steps.js
+++ b/src/components/TestQuery/Steps.js
@@ -178,9 +178,16 @@ class SetQueryStep extends Component {
           <br/>
           <div>
             <h2>Some examples of {dataSource} Queries</h2>
-            <ul>
-              {getDataSourceObj(dataSource).sampleQueries.map(sample => <li key={sample}>{sample}</li>)}
-            </ul>
+            <div className="sample-query-list">
+              {getDataSourceObj(dataSource).sampleQueries.map(sample => {
+                return (
+                  <div className="sample-query-item">
+                    <div className="sample-query-title">{sample.title}:</div>
+                    <div className="sample-query">{sample.query}</div>
+                  </div>
+                );
+              })}
+            </div>
           </div>
           <FormItem
             label="Enter a query to text">


### PR DESCRIPTION
# Why?

Current copy was a bit hard to read.

# What Changed?

- Reworked the `sampleQueries` array to include objects with `query` and `title`.
- Output the `sampleQueries` array to new `.sample-query-list` element.

# Example

![image](https://user-images.githubusercontent.com/1138619/36273359-3cd0d2ae-1252-11e8-9faa-ade098620e99.png)

### References
#43 