### PR TITLE
Reorder deployment steps

### DIFF
--- a/src/components/DeployContract/GuidedDeployment.js
+++ b/src/components/DeployContract/GuidedDeployment.js
@@ -66,6 +66,14 @@ class GuidedDeployment extends Component {
         updateDeploymentState={this.setState.bind(this)}
         {...this.state} />,
 
+      <DataSourceStep
+        key="3"
+        onPrevClicked={this.toPrevStep.bind(this)}
+        onNextClicked={this.toNextStep.bind(this)}
+        updateDeploymentState={this.setState.bind(this)}
+        initialValues={initialValues}
+        {...this.state} />,
+
       <PricingStep 
         key="1"
         onPrevClicked={this.toPrevStep.bind(this)}
@@ -78,14 +86,6 @@ class GuidedDeployment extends Component {
         onPrevClicked={this.toPrevStep.bind(this)}
         onNextClicked={this.toNextStep.bind(this)}
         updateDeploymentState={this.setState.bind(this)} 
-        {...this.state} />,
-
-      <DataSourceStep
-        key="3"
-        onPrevClicked={this.toPrevStep.bind(this)}
-        onNextClicked={this.toNextStep.bind(this)}
-        updateDeploymentState={this.setState.bind(this)}
-        initialValues={initialValues}
         {...this.state} />,
 
       <DeployStep
@@ -101,9 +101,9 @@ class GuidedDeployment extends Component {
         <Col {...parentColLayout}>
           <Steps current={currentStep}>
             <Step title="Name"/>
+            <Step title="Data Source" />
             <Step title="Pricing" />
             <Step title="Expiration" />
-            <Step title="Data Source" />
             <Step title="Deploy" />
           </Steps>
           <br/>

--- a/src/components/DeployContract/Steps.js
+++ b/src/components/DeployContract/Steps.js
@@ -110,9 +110,8 @@ class NameContractStep extends BaseStepComponent {
                form={this.props.form}/>
         <Row type="flex" justify="end">
           <Col>
-            <Button type="primary" htmlType="submit">
-              Set Pricing Range<Icon type="arrow-right"/>
-            </Button>
+            <BiDirectionalNav text="Select Oracle" {...this.props} />
+            {/* <BiDirectionalNav text="Deploy Contract" {...this.props} /> */}
           </Col>
         </Row>
       </Form>
@@ -221,7 +220,7 @@ class ExpirationStep extends BaseStepComponent {
                form={this.props.form}/>
         <Row type="flex" justify="end">
           <Col>
-            <BiDirectionalNav text="Select Oracle" {...this.props} />
+            <BiDirectionalNav text="Deploy Contract" {...this.props} />
           </Col>
         </Row>
       </Form>
@@ -277,7 +276,9 @@ class DataSourceStep extends BaseStepComponent {
 
         <Row type="flex" justify="end">
           <Col>
-            <BiDirectionalNav text="Deploy Contract" {...this.props} />
+            <Button type="primary" htmlType="submit">
+              Set Pricing Range<Icon type="arrow-right"/>
+            </Button>
           </Col>
         </Row>
       </Form>


### PR DESCRIPTION
# Why?
Steps for the Guided Contract Deployer should be modified / reorganized to move the data source closer to naming and before worrying about pricing

# What Change?
Reorder the `<Steps...` component and add proper 'next' buttons.

# Example
![image](https://user-images.githubusercontent.com/1138619/36404948-c747bf4e-15bb-11e8-86aa-1751ad6a409d.png)

#### Refers
#46 